### PR TITLE
Added toggle to highlight regex capture groups

### DIFF
--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -3,7 +3,7 @@ import { SelectionHighlightOptions } from "../highlighters/selection";
 import { ignoredWords } from "./ignoredWords";
 import { StyleSpec } from "style-mod";
 
-export type markTypes = "line" | "match";
+export type markTypes = "line" | "match" | "groups";
 
 export type SettingValue = number | string | boolean;
 export interface CSSSettings {

--- a/src/settings/ui.ts
+++ b/src/settings/ui.ts
@@ -460,6 +460,21 @@ export class SettingTab extends PluginSettingTab {
       );
     });
 
+    // "groups" toggle, to highlight regex capture groups instead of whole match
+    defineQueryUIBottom.controlEl.createSpan("groups-text").setText("groups");
+    const groupsToggle = new ToggleComponent(
+      defineQueryUIBottom.controlEl
+    ).setValue(false);
+    groupsToggle.setTooltip("Highlight regex capture groups");
+    groupsToggle.toggleEl.addClass("groups-toggle");
+    groupsToggle.onChange((active) => {
+      regexToggle.setValue(active || regexToggle.getValue());
+      groupsToggle.setTooltip(`${active ? "Deactivate" : "Activate"} regex capture group highlighting`);
+      if (active && !queryInput.getValue().contains("(")) {
+        new Notice("Your regex does not contain any capture groups");
+      }
+    });
+
     // The save Button
     // helper variable stores highlighter to enable changing its other settings
     let currentHighlighterName: string | null = null;
@@ -506,6 +521,11 @@ export class SettingTab extends PluginSettingTab {
             enabledMarks.push("line");
           } else {
             enabledMarks = enabledMarks.filter((value) => value != "line");
+          }
+          if (groupsToggle.getValue() && !enabledMarks.includes("groups")) {
+            enabledMarks.push("groups");
+          } else {
+            enabledMarks = enabledMarks.filter((value) => value != "groups");
           }
           return enabledMarks;
         };
@@ -1034,7 +1054,7 @@ export class SettingTab extends PluginSettingTab {
                 tagStatus = options.tagEnabled;
                 staticPickrInstance.setColor(options.staticColor);
                 regexToggle.setValue(options.regex);
-                // matcheToggle / lineToggle
+                // matcheToggle / lineToggle / groupsToggle
                 if (options?.mark) {
                   if (options?.mark.includes("match")) {
                     matchToggle.setValue(true);
@@ -1045,6 +1065,11 @@ export class SettingTab extends PluginSettingTab {
                     lineToggle.setValue(true);
                   } else {
                     lineToggle.setValue(false);
+                  }
+                  if (options?.mark.includes("groups")) {
+                    groupsToggle.setValue(true);
+                  } else {
+                    groupsToggle.setValue(false);
                   }
                 }
                 containerEl.scrollTop = 0;


### PR DESCRIPTION
## Description
Added support for regex capture groups (`"(.*?)"`) for more granularity in highlights.

## Examples
#### Current behavior for capture groups ("groups" toggle is OFF):
<img width="1400" height="266" alt="image" src="https://github.com/user-attachments/assets/b322e82c-ca9b-4a5c-b668-1c1a429c2253" />
<img width="500" height="130" alt="image" src="https://github.com/user-attachments/assets/97e1171a-718b-4b73-aa33-7d6bcdca3fb0" />

#### With "groups" toggle ON:
<img width="1392" height="270" alt="image" src="https://github.com/user-attachments/assets/07f1c72f-4a8d-4fe7-a9e3-5af3ea03570a" />
<img width="496" height="122" alt="image" src="https://github.com/user-attachments/assets/1d5e2bb3-ab71-4710-a97a-ffc8e9d640e3" />
