### PR TITLE
feat: UI improvements - debug mode, dark theme, responsive layout, duplicate rule

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -346,7 +346,8 @@ export default class AnotherDynamicHighlightsPlugin extends Plugin {
 
       // Only log if matches are found
       if (matches.length > 0) {
-        console.log("Found matches in text:", {
+        if (this.settings.staticHighlighter.debugMode) {
+          console.log("Found matches in text:", {
           text: nodeText,
           pattern: pattern,
           matches: matches.map((m) => ({
@@ -354,6 +355,7 @@ export default class AnotherDynamicHighlightsPlugin extends Plugin {
             index: m.index,
           })),
         });
+        }
 
         const fragment = document.createDocumentFragment();
         let lastIndex = 0;

--- a/src/highlighters/static.ts
+++ b/src/highlighters/static.ts
@@ -25,6 +25,7 @@ import { NodeProp } from "@lezer/common";
 
 export type StaticHighlightOptions = {
   showInReadingMode: boolean;
+  debugMode: boolean;
   queries: SearchQueries;
   queryOrder: string[];
   tagOrder: string[];
@@ -37,6 +38,7 @@ const tokenClassNodeProp = new NodeProp();
 
 const defaultOptions: StaticHighlightOptions = {
   showInReadingMode: false,
+  debugMode: false,
   queries: {},
   queryOrder: [],
   tagOrder: [],
@@ -174,7 +176,9 @@ const staticHighlighter = ViewPlugin.fromClass(
                   part.to
                 );
             } catch (err) {
-              console.debug(err);
+              if (view.state.facet(staticHighlightConfig).debugMode) {
+                console.debug(err);
+              }
               continue;
             }
             while (!cursor.next().done) {

--- a/src/settings/modals.ts
+++ b/src/settings/modals.ts
@@ -182,7 +182,9 @@ export class DeleteTagModal extends Modal {
 
     tagDeleteDecision.placeholder = `Delete ${this.oldTagName}!`;
 
-    const deleteButton = new ButtonComponent(contentEl);
+    const buttonContainer = contentEl.createDiv("modal-button-container");
+
+    const deleteButton = new ButtonComponent(buttonContainer);
     deleteButton.setClass("action-button");
     deleteButton.setClass("action-button-modal");
     deleteButton.setClass("action-button-delete");
@@ -218,7 +220,7 @@ export class DeleteTagModal extends Modal {
       }
     });
 
-    const cancelButton = new ButtonComponent(contentEl);
+    const cancelButton = new ButtonComponent(buttonContainer);
     cancelButton.setClass("action-button");
     cancelButton.setClass("action-button-cancel");
     cancelButton.setCta();
@@ -261,7 +263,9 @@ export class DeleteHighlighterModal extends Modal {
       cls: "Tag-modal-helper",
     });
 
-    const deleteButton = new ButtonComponent(contentEl);
+    const buttonContainer = contentEl.createDiv("modal-button-container");
+
+    const deleteButton = new ButtonComponent(buttonContainer);
     deleteButton.setClass("action-button");
     deleteButton.setClass("action-button-delete-modal");
     deleteButton.setWarning();
@@ -281,7 +285,7 @@ export class DeleteHighlighterModal extends Modal {
       }
     });
 
-    const cancelButton = new ButtonComponent(contentEl);
+    const cancelButton = new ButtonComponent(buttonContainer);
     cancelButton.setClass("action-button");
     cancelButton.setClass("action-button-cancel");
     cancelButton.setCta();

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -50,6 +50,7 @@ export const DEFAULT_SETTINGS: AnotherDynamicHighlightsSettings = {
   },
   staticHighlighter: {
     showInReadingMode: false,
+    debugMode: false,
     queries: {},
     queryOrder: [],
     tagOrder: [],

--- a/src/settings/ui.ts
+++ b/src/settings/ui.ts
@@ -65,7 +65,9 @@ export class SettingTab extends PluginSettingTab {
       }
       const resolveColor = () =>
         color === "default" ? "var(--text-accent)" : color;
-      if (deco == "background") {
+      if (deco == "none") {
+        cssSnippet = "";
+      } else if (deco == "background") {
         cssSnippet = `background-color: ${resolveColor()}`;
       } else if (deco == "background rounded") {
         cssSnippet = `position: relative; background-color: ${resolveColor()}; padding: 0.15em 0.25em; margin: 0; border-radius: 0.25em; box-decoration-break: clone; -webkit-box-decoration-break: clone; background-clip: padding-box; background-image: linear-gradient(to right, ${resolveColor()}dd, ${resolveColor()} 50%, ${resolveColor()}dd); box-shadow: inset 0 0 0 1px ${resolveColor()}22; display: inline;`;
@@ -220,6 +222,7 @@ export class SettingTab extends PluginSettingTab {
       .setClass("define-query-ui");
 
     const defineQueryUITop = new Setting(defineQueryUI.controlEl);
+    defineQueryUITop.setClass("define-query-ui-top-container");
 
     // Input field for the highlighter name
     const queryNameInput = new TextComponent(defineQueryUITop.controlEl);
@@ -384,6 +387,7 @@ export class SettingTab extends PluginSettingTab {
           dropdown.selectEl.classList.add("has-tooltip");
         }
         dropdown
+          .addOption("none", "None (class only)")
           .addOption("background", "Background square")
           .addOption("background rounded", "--- rounded")
           .addOption("background realistic", "--- realistic")
@@ -413,10 +417,14 @@ export class SettingTab extends PluginSettingTab {
           });
       });
 
+    // Toggles grid container
+    const togglesGrid = defineQueryUIBottom.controlEl.createDiv("toggles-grid");
+
     // RegEx toggle
-    defineQueryUIBottom.controlEl.createSpan("regex-text").setText("regEx");
+    const regexPair = togglesGrid.createDiv("toggle-pair");
+    regexPair.createSpan("regex-text").setText("regEx");
     const regexToggle = new ToggleComponent(
-      defineQueryUIBottom.controlEl,
+      regexPair,
     ).setValue(false);
     regexToggle.setTooltip("Activate RegEx");
     regexToggle.toggleEl.addClass("regex-toggle");
@@ -431,9 +439,10 @@ export class SettingTab extends PluginSettingTab {
     });
 
     // "match" toggle, to decorate matched characters
-    defineQueryUIBottom.controlEl.createSpan("matches-text").setText("matches");
+    const matchPair = togglesGrid.createDiv("toggle-pair");
+    matchPair.createSpan("matches-text").setText("matches");
     const matchToggle = new ToggleComponent(
-      defineQueryUIBottom.controlEl,
+      matchPair,
     ).setValue(true);
     matchToggle.setTooltip("Deactivate highlighting matches");
     matchToggle.toggleEl.addClass("matches-toggle");
@@ -448,9 +457,10 @@ export class SettingTab extends PluginSettingTab {
     });
 
     // "line" toggle, to decorate the entire parent line
-    defineQueryUIBottom.controlEl.createSpan("line-text").setText("lines");
+    const linePair = togglesGrid.createDiv("toggle-pair");
+    linePair.createSpan("line-text").setText("lines");
     const lineToggle = new ToggleComponent(
-      defineQueryUIBottom.controlEl,
+      linePair,
     ).setValue(false);
     lineToggle.setTooltip("Activate higlighting of parent line");
     lineToggle.toggleEl.addClass("line-toggle");
@@ -464,9 +474,10 @@ export class SettingTab extends PluginSettingTab {
     });
 
     // "groups" toggle, to highlight regex capture groups instead of whole match
-    defineQueryUIBottom.controlEl.createSpan("groups-text").setText("groups");
+    const groupsPair = togglesGrid.createDiv("toggle-pair");
+    groupsPair.createSpan("groups-text").setText("groups");
     const groupsToggle = new ToggleComponent(
-      defineQueryUIBottom.controlEl,
+      groupsPair,
     ).setValue(false);
     groupsToggle.setTooltip("Highlight regex capture groups");
     groupsToggle.toggleEl.addClass("groups-toggle");
@@ -480,10 +491,11 @@ export class SettingTab extends PluginSettingTab {
       }
     });
 
-    // The save Button
+    // The save & discard buttons group
     // helper variable stores highlighter to enable changing its other settings
     let currentHighlighterName: string | null = null;
-    const saveButton = new ButtonComponent(defineQueryUITop.controlEl);
+    const buttonsGroup = defineQueryUITop.controlEl.createDiv("define-buttons-group");
+    const saveButton = new ButtonComponent(buttonsGroup);
     saveButton.buttonEl.setAttribute("state", "creating");
     saveButton
       .setClass("save-button")
@@ -566,7 +578,9 @@ export class SettingTab extends PluginSettingTab {
             staticHexValue === "default"
               ? "var(--text-accent)"
               : staticHexValue;
-          if (staticDecorationValue === "background") {
+          if (staticDecorationValue === "none") {
+            staticCssSnippet = {};
+          } else if (staticDecorationValue === "background") {
             staticCssSnippet = {
               backgroundColor: resolveColor02(),
             };
@@ -723,7 +737,7 @@ export class SettingTab extends PluginSettingTab {
       });
 
     // The discard button
-    const discardButton = new ButtonComponent(defineQueryUITop.controlEl);
+    const discardButton = new ButtonComponent(buttonsGroup);
     discardButton
       .setClass("discard-button")
       .setClass("action-button")
@@ -1035,6 +1049,43 @@ export class SettingTab extends PluginSettingTab {
 
         highlighterButtons
           .addButton((button) => {
+            button.setTooltip(`Duplicate ${highlighter} as a new highlighter`);
+            button
+              .setClass("action-button")
+              .setClass("action-button-highlighterslist")
+              .setClass("mod-cta-inverted")
+              .setIcon("copy")
+              .onClick(async () => {
+                const options = config.queries[highlighter];
+                let copyName = highlighter + " (copy)";
+                let counter = 1;
+                while (config.queries[copyName]) {
+                  counter++;
+                  copyName = highlighter + ` (copy ${counter})`;
+                }
+                config.queries[copyName] = {
+                  class: copyName.replace(/ /g, "-"),
+                  staticColor: options.staticColor,
+                  staticDecoration: options.staticDecoration,
+                  staticCss: { ...options.staticCss },
+                  colorIconSnippet: options.colorIconSnippet,
+                  regex: options.regex,
+                  query: options.query,
+                  mark: options.mark ? [...options.mark] : undefined,
+                  highlighterEnabled: true,
+                  tag: options.tag,
+                  tagEnabled: options.tagEnabled,
+                };
+                const tagIndex = config.queryOrder.indexOf(highlighter);
+                config.queryOrder.splice(tagIndex + 1, 0, copyName);
+                await this.plugin.saveSettings();
+                this.plugin.updateStaticHighlighter();
+                this.plugin.updateStyles();
+                this.display();
+                new Notice(`Duplicated as "${copyName}"`);
+              });
+          })
+          .addButton((button) => {
             button.setTooltip(`Edit ${highlighter} highlighter`);
             button
               .setClass("action-button")
@@ -1118,6 +1169,19 @@ export class SettingTab extends PluginSettingTab {
           .setValue(this.plugin.settings.staticHighlighter.showInReadingMode)
           .onChange(async (value) => {
             this.plugin.settings.staticHighlighter.showInReadingMode = value;
+            await this.plugin.saveSettings();
+          });
+      });
+    new Setting(this.containerEl)
+      .setName("Debug mode")
+      .setDesc(
+        "If enabled, match details will be logged to the developer console.",
+      )
+      .addToggle((toggle) => {
+        toggle
+          .setValue(this.plugin.settings.staticHighlighter.debugMode)
+          .onChange(async (value) => {
+            this.plugin.settings.staticHighlighter.debugMode = value;
             await this.plugin.saveSettings();
           });
       });
@@ -1241,6 +1305,7 @@ export class SettingTab extends PluginSettingTab {
           dropdown.selectEl.classList.add("has-tooltip");
         }
         dropdown
+          .addOption("none", "None (class only)")
           .addOption("background", "Background square")
           .addOption("background rounded", "--- rounded")
           .addOption("background realistic", "--- realistic")

--- a/styles.css
+++ b/styles.css
@@ -73,56 +73,72 @@
   align-content: center;
   align-items: center;
   flex-wrap: wrap;
-  justify-content: flex-start;
   border-top: none;
 }
 
 /* FLEXBOX TOP ROW */
 .define-query-ui-top-container {
+  border-top: none;
+  padding: 0;
+}
+
+.define-query-ui-top-container > .setting-item-info {
+  display: none;
+}
+
+.define-query-ui-top-container > .setting-item-control {
   display: flex;
   gap: 5px;
   align-items: center;
-  height: 30px;
-  line-height: 30px;
-  justify-content: center;
-  border-bottom: none;
-  padding-bottom: 0px;
+  flex-wrap: wrap;
+  width: 100%;
 }
 
 .define-query-ui-top-container .setting-item {
-  padding: 0px 0px 0px;
+  padding: 0;
 }
 
 /* Reorder elements in the flexbox */
 .query-name-input {
   order: -3;
   margin: 0;
+  min-width: 80px;
+  flex: 1 1 80px;
 }
 
 .color-button-wrapper {
   order: -2;
+  flex-shrink: 0;
 }
 
 .query-input {
   order: -1;
   margin: 0;
   padding: 0;
+  min-width: 80px;
+  flex: 1 1 80px;
 }
 
 
-.tag-dropdown-wrapper{
+.tag-dropdown-wrapper {
   margin: 0;
+  flex-shrink: 0;
 }
+
+/* Collapse the nested Setting inside tag-dropdown */
+.tag-dropdown-wrapper .setting-item-info {
+  display: none;
+}
+
 .tag-dropdown {
   order: 0;
   margin: 0;
-  margin-right: 5px;
-  padding: 4px;
-  max-width: 100px;
+  padding: 0;
+  border-top: none;
+  max-width: 110px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  display: inline-block;
   background-image: none;
 }
 
@@ -134,73 +150,79 @@
   text-overflow: ellipsis;
 }
 
-.save-button {
-  order: 2;
-}
-
-.discard-button {
-  order: 3;
-}
-
-.dynamic-highlights-settings .action-button.action-button-save {
-  align-self: center;
+.define-buttons-group {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  flex-shrink: 0;
   margin-left: auto;
 }
 
-.dynamic-highlights-settings .action-button.action-button-discard {
-  align-self: center;
-  margin-left: auto;
+.define-buttons-group .action-button {
+  margin-right: 0;
+  padding: 6px 12px;
 }
 
 /* Contains the dropdown, regEx and marks */
 .define-query-ui-bottom-container {
-  display: flex;
-  gap: 5px;
-  align-items: center;
-  height: 30px;
-  line-height: 30px;
-  justify-content: center;
-  margin-top: -3px;
   border-top: none;
+  padding: 0;
   margin-bottom: 10px;
 }
 
-/* Reorder elements in the flexbox */
+.define-query-ui-bottom-container > .setting-item-info {
+  display: none;
+}
+
+.dynamic-highlights-settings .define-query-ui-bottom-container > .setting-item-control {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  flex-wrap: wrap;
+}
+
+/* Collapse nested Setting inside deco-dropdown */
+.deco-dropdown .setting-item-info {
+  display: none;
+}
+
+.deco-dropdown .setting-item.deco-dropdown {
+  border-top: none;
+  padding: 0;
+}
+
 .deco-dropdown {
-  order: 0;
-  margin-top: 3px;
-  margin-left: -18px;
-  margin-right: 5px;
+  margin: 0;
+  flex-shrink: 0;
 }
 
-.regEx-text {
-  order: 1;
-  text-align: start;
-  margin-right: -3px;
+/* Toggles grid: 4 cols when wide, 2 cols when narrow */
+.toggles-grid {
+  display: grid;
+  grid-template-columns: repeat(2, auto);
+  gap: 2px 10px;
+  align-items: center;
+  margin-left: auto;
 }
 
-.regEx-toggle {
-  order: 2;
-  margin-right: 5px;
+@media (min-width: 700px) {
+  .toggles-grid {
+    grid-template-columns: repeat(4, auto);
+  }
 }
 
-.matches-text {
-  order: 3;
-  text-align: start;
-  margin-left: 10px;
+/* Each toggle pair (label + checkbox) inline */
+.toggle-pair {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  white-space: nowrap;
 }
 
-.matches-toggle {
-  order: 4;
-}
-
-.line-text {
-  order: 5;
-  margin-left: 10px;
-}
-
-.line-toggle {
-  order: 6;
+.toggle-pair > span {
+  font-size: var(--font-smallest);
 }
 
 /* ##################### YOUR HIGHLIGHTERS AND TAGS #####################*/
@@ -223,10 +245,14 @@
 }
 
 .tag-container {
-  border: 1px solid #ccc;
-  /*border-radius: 10px;*/
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 8px;
   padding: 15px;
-  /*background-color: #bbb3c638;*/
+  margin-bottom: 8px;
+}
+
+.tag-container .setting-item {
+  background: transparent;
 }
 
 .tag-container .tag-header {
@@ -238,7 +264,14 @@
 .tag-header-buttons {
   display: flex;
   align-items: center;
+  gap: 4px;
   border: none;
+  flex-shrink: 0;
+}
+
+.tag-header-buttons .action-button {
+  margin-right: 0;
+}
 }
 
 .tag-header .toggle-icon {
@@ -253,7 +286,7 @@
   font-weight: 600;
   font-size: medium;
   border-bottom: 1px;
-  background-color: #ffffff;
+  background-color: var(--background-primary);
   cursor: pointer;
 }
 
@@ -311,9 +344,18 @@
   .highlighter-container
   .highlighter-details
   .setting-item-control {
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   flex-grow: 0;
   border-top: none;
+  gap: 4px;
+}
+
+.dynamic-highlights-settings
+  .highlighter-container
+  .highlighter-details
+  .setting-item-control .action-button {
+  margin-right: 0;
+  padding: 6px 12px;
 }
 
 /* ##################### BUTTON, TOGGLE AND TEXT AREA STYLES #####################*/
@@ -359,53 +401,36 @@
 }
 
 .selectedHighlightsStylingsContainer {
-  display: grid;
-  grid-template-columns:
-    [example] auto
-    [color-picker] auto
-    [spacer1] 5px
-    [drop-down] auto
-    [spacer2] 10px
-    [save] auto
-    [selected-discard-button] auto
-    [spacer3] 10px [end];
-  grid-template-rows: [row] auto;
-  gap: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
   width: 100%;
   align-items: center;
 }
 
 .selectedHighlightsStylingsContainer .example {
-  grid-column: example;
   text-align: left;
-  width: 100%;
 }
 
 .selectedHighlightsStylingsContainer .selection-color-picker {
-  grid-column: color-picker;
 }
 
 .selectedHighlightsStylingsContainer .choose-decoration-text {
-  grid-column: choose_deco;
   text-align: left;
 }
 
 .selectedHighlightsStylingsContainer .decoration-dropdown {
-  grid-column: drop-down;
   border: none;
 }
 
 .selectedHighlightsStylingsContainer .selected-save-button {
-  grid-column: save;
 }
 
 .selectedHighlightsStylingsContainer .selected-discard-button {
-  grid-column: selected-discard-button;
 }
 
 .selectedHighlightsStylingsContainer .selected-spacer {
-  grid-column: spacer3;
-  border: none;
+  display: none;
 }
 
 /* ##################### BUTTONS AND STUFF I DON'T UNDERSTAND #####################*/
@@ -418,7 +443,7 @@
   place-content: center;
   padding: 8px 18px;
   /* set this to the obsidian default to address theme devs messing with it 👀 */
-  margin-right: 12px;
+  margin-right: 0;
 }
 
 .modal-warning-text {
@@ -954,6 +979,13 @@
 /* #endregion pickr vendored styles */
 
 /* ##################### MODALS #####################*/
+.modal-button-container {
+  display: flex;
+  gap: 10px;
+  margin-top: 16px;
+  justify-content: flex-end;
+}
+
 .tag-modal-text {
   width: 400px;
   margin-top: -10px;
@@ -1139,7 +1171,7 @@
   display: grid;
   place-content: center;
   padding: 8px 18px;
-  margin-right: 12px;
+  margin-right: 0;
 }
 
 /* Search term & save region */


### PR DESCRIPTION
## Summary

A collection of UI/UX improvements covering settings panel usability, dark theme compatibility, and responsive layout fixes.

### New Features

- **Debug mode toggle** (default: off) — Gates verbose console output (`Found matches in text` logs and regex error debug messages). Adds a toggle in the settings panel under "Show highlights in reading mode".
- **"None (class only)" decoration option** — New decoration style that applies only the CSS class to matched text without any inline styles, allowing users to define their own styling via CSS snippets.
- **Duplicate highlighter button** — Copy icon button on each highlighter rule that clones the rule with a `(copy)` suffix, inserted right after the original.

<img width="957" height="414" alt="Snipaste_2026-04-24_16-41-57" src="https://github.com/user-attachments/assets/6712593f-79f6-42de-ab5d-324507fbdea3" />


### CSS / Dark Theme Fixes

- `.tag-header .tag-name` background: `#ffffff` → `var(--background-primary)` for dark theme compatibility
- `.tag-container` border: `#ccc` → `var(--background-modifier-border)`, added `border-radius: 8px`, spacing between containers, and transparent background for inner setting items

Before:

<img width="1044" height="730" alt="image" src="https://github.com/user-attachments/assets/c25acf54-7ae8-4621-b04d-b2424743bb29" />


After:

<img width="1044" height="730" alt="image" src="https://github.com/user-attachments/assets/b93cb6ef-ff43-452a-9c25-f45bd50fd0f9" />


### Responsive Layout Fixes

- **Settings define row (top)**: inputs use `flex: 1 1 80px` with `flex-wrap`, save/discard grouped in a flex container pushed right via `margin-left: auto`
- **Settings define row (bottom)**: deco-dropdown left-aligned, toggles right-aligned via `margin-left: auto`; each toggle label+checkbox paired in `.toggle-pair` divs inside a `.toggles-grid` with responsive 2-col / 4-col layout
- **Highlighter details buttons**: `flex-wrap: wrap` with `gap: 4px` to prevent overflow on narrow panels
- **Selection highlights area**: fixed-column grid → `flex-wrap` to prevent horizontal overflow
- **Modal buttons**: wrapped in `.modal-button-container` with flex layout, gap, and right alignment
- **Global**: removed hardcoded `margin-right: 12px` on `.action-button`, replaced with `gap` on parent containers
- **Nested Settings**: hidden empty `.setting-item-info` divs inside tag-dropdown and deco-dropdown to eliminate wasted space

Compare:

<img width="1086" height="473" alt="image" src="https://github.com/user-attachments/assets/8684c05f-368b-418d-9b93-6e9d8f3d5f66" />
